### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/vpswireguardmikrotik.html
+++ b/vpswireguardmikrotik.html
@@ -446,6 +446,76 @@
         footer p {
             color: rgba(226, 232, 240, 0.85);
         }
+
+        @media (max-width: 768px) {
+            .container {
+                padding: 1.25rem;
+            }
+            .hero-inner {
+                padding: 4rem 0 3.5rem;
+                gap: 2rem;
+            }
+            .hero-description {
+                font-size: 1rem;
+            }
+            .hero-meta {
+                grid-template-columns: 1fr;
+            }
+            .progress-grid {
+                grid-template-columns: 1fr;
+            }
+            .step-card {
+                padding: 1.75rem;
+                margin-bottom: 1.5rem;
+            }
+            .step-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.75rem;
+            }
+            .step-header svg {
+                align-self: flex-end;
+            }
+            .diagram-container {
+                height: auto;
+                min-height: 280px;
+                padding: 1.25rem;
+            }
+            .chart-container {
+                height: 260px;
+            }
+            .tab-buttons {
+                flex-direction: column;
+            }
+            .tab-button {
+                width: 100%;
+                text-align: center;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .container {
+                padding: 1rem;
+            }
+            .hero-title {
+                font-size: clamp(2rem, 9vw, 2.75rem);
+            }
+            .hero-description {
+                font-size: 0.95rem;
+            }
+            .hero-card {
+                padding: 1rem 1.1rem;
+            }
+            .quick-nav {
+                padding: 1.25rem;
+            }
+            .progress-item {
+                align-items: flex-start;
+            }
+            .step-card {
+                padding: 1.5rem;
+            }
+        }
     </style>
 </head>
 <body class="antialiased">


### PR DESCRIPTION
## Summary
- add tablet and phone breakpoints to refine spacing, typography, and card layout
- ensure navigation, progress tracker, and diagrams stay legible on smaller screens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbe3a93dc08322a35d499a0f6f3710