### PR TITLE
Ensure chart and diagram containers use border-box sizing

### DIFF
--- a/vpswireguardmikrotik.html
+++ b/vpswireguardmikrotik.html
@@ -305,11 +305,13 @@
             .chart-container {
                 padding: 1.1rem;
                 height: auto;
+                box-sizing: border-box;
             }
             .diagram-container {
                 padding: 1.1rem;
                 height: auto;
                 min-height: 320px;
+                box-sizing: border-box;
             }
         }
         @media (max-width: 640px) {
@@ -500,6 +502,7 @@
             background-color: #f9fafb;
             border-radius: 0.75rem;
             padding: 1rem;
+            box-sizing: border-box;
         }
         .diagram-container {
             position: relative;
@@ -513,6 +516,7 @@
             align-items: center;
             flex-direction: column;
             margin-top: 1.5rem;
+            box-sizing: border-box;
         }
         .diagram-container svg {
             overflow: visible;
@@ -599,9 +603,11 @@
                 height: auto;
                 min-height: 280px;
                 padding: 1.25rem;
+                box-sizing: border-box;
             }
             .chart-container {
                 height: 260px;
+                box-sizing: border-box;
             }
             .tab-buttons {
                 flex-direction: column;


### PR DESCRIPTION
## Summary
- add border-box sizing to the base chart and diagram containers so padding no longer expands their width
- mirror the border-box sizing in responsive overrides to avoid horizontal overflow on smaller screens

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cc0079bcf0832290f56a545f2ffdc4