### PR TITLE
Add SEO metadata for WireGuard Mikrotik tutorial page

### DIFF
--- a/vpswireguardmikrotik.html
+++ b/vpswireguardmikrotik.html
@@ -3,6 +3,34 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Panduan lengkap membangun tunnel WireGuard antara VPS Linux dan Mikrotik: persiapan server, konfigurasi router, routing, firewall, dan tips pemecahan masalah.">
+    <link rel="canonical" href="https://tutorwireguard.com/vpswireguardmikrotik">
+    <meta property="og:title" content="Tutorial Wireguard Site-to-Site Lengkap">
+    <meta property="og:description" content="Panduan lengkap membangun tunnel WireGuard antara VPS Linux dan Mikrotik: persiapan server, konfigurasi router, routing, firewall, dan tips pemecahan masalah.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://tutorwireguard.com/vpswireguardmikrotik">
+    <meta property="og:image" content="https://tutorwireguard.com/images/vps-wireguard-mikrotik-hero.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Tutorial Wireguard Site-to-Site Lengkap">
+    <meta name="twitter:description" content="Panduan lengkap membangun tunnel WireGuard antara VPS Linux dan Mikrotik: persiapan server, konfigurasi router, routing, firewall, dan tips pemecahan masalah.">
+    <meta name="twitter:image" content="https://tutorwireguard.com/images/vps-wireguard-mikrotik-hero.png">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "Article",
+            "headline": "Tutorial Wireguard Site-to-Site Lengkap",
+            "description": "Panduan lengkap membangun tunnel WireGuard antara VPS Linux dan Mikrotik: persiapan server, konfigurasi router, routing, firewall, dan tips pemecahan masalah.",
+            "author": {
+                "@type": "Organization",
+                "name": "Tutor WireGuard"
+            },
+            "datePublished": "2024-01-15",
+            "mainEntityOfPage": {
+                "@type": "WebPage",
+                "@id": "https://tutorwireguard.com/vpswireguardmikrotik"
+            }
+        }
+    </script>
     <title>Tutorial Wireguard Site-to-Site Lengkap</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>


### PR DESCRIPTION
## Summary
- add a localized meta description, canonical URL, and social sharing tags to the Mikrotik WireGuard tutorial
- include a schema.org Article JSON-LD block to enrich search engine snippets

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccab302750832293cb8aaf126d1769